### PR TITLE
feat(cli): add remaining user commands

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -77,6 +77,12 @@ enum Command {
         command: user::UserCommand,
     },
 
+    #[clap(about = "User profile commands")]
+    Profile {
+        #[clap(subcommand)]
+        command: user::ProfileCommand,
+    },
+
     #[clap(about = "Group commands")]
     Group {
         #[clap(subcommand)]
@@ -124,6 +130,7 @@ fn main() {
         Command::AnalyticsProvider { command } => command.execute(api),
         Command::Comment { ref command } => command.execute(api),
         Command::User { ref command } => command.execute(api),
+        Command::Profile { ref command } => command.execute(api),
         Command::Group { command } => command.execute(api),
         Command::Locale { command } => command.execute(api),
         Command::Logger { command } => command.execute(api),

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -83,6 +83,12 @@ enum Command {
         command: user::ProfileCommand,
     },
 
+    #[clap(about = "Password commands")]
+    Password {
+        #[clap(subcommand)]
+        command: user::PasswordCommand,
+    },
+
     #[clap(about = "Group commands")]
     Group {
         #[clap(subcommand)]
@@ -131,6 +137,7 @@ fn main() {
         Command::Comment { ref command } => command.execute(api),
         Command::User { ref command } => command.execute(api),
         Command::Profile { ref command } => command.execute(api),
+        Command::Password { ref command } => command.execute(api),
         Command::Group { command } => command.execute(api),
         Command::Locale { command } => command.execute(api),
         Command::Logger { command } => command.execute(api),

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -418,7 +418,11 @@ fn user_profile(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
 fn user_last_logins(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
     let logins = api.user_last_login_list()?;
     let mut builder = Builder::new();
-    builder.push_record(["key", "value"]);
+    builder.push_record([
+        "id",
+        "name",
+        "last_login_at",
+    ]);
     for login in logins {
         builder.push_record([
             login.id.to_string().as_str(),

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -54,6 +54,12 @@ pub(crate) enum UserCommand {
         #[clap(short, long, help = "Send welcome email")]
         send_welcome_email: Option<bool>,
     },
+
+    #[clap(about = "Activate a user")]
+    Activate {
+        #[clap(help = "User ID")]
+        id: i64,
+    },
 }
 
 impl Execute for UserCommand {
@@ -81,6 +87,7 @@ impl Execute for UserCommand {
                 *must_change_password,
                 *send_welcome_email,
             ),
+            UserCommand::Activate { id } => user_activate(api, *id),
         }
     }
 }
@@ -176,5 +183,11 @@ fn user_create(
         send_welcome_email,
     )?;
     println!("{}: User created", "success".bold().green());
+    Ok(())
+}
+
+fn user_activate(api: wikijs::Api, id: i64) -> Result<(), Box<dyn Error>> {
+    api.user_activate(id)?;
+    println!("{}: User activated", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -149,6 +149,27 @@ pub(crate) enum UserCommand {
         #[clap(short, long, help = "Appearance")]
         appearance: Option<String>,
     },
+
+    #[clap(about = "Update your user profile")]
+    ProfileUpdate {
+        #[clap(help = "Name")]
+        name: String,
+
+        #[clap(help = "Location")]
+        location: String,
+
+        #[clap(help = "Job title")]
+        job_title: String,
+
+        #[clap(help = "Timezone")]
+        timezone: String,
+
+        #[clap(help = "Date format")]
+        date_format: String,
+
+        #[clap(help = "Appearance")]
+        appearance: String,
+    },
 }
 
 impl Execute for UserCommand {
@@ -206,6 +227,22 @@ impl Execute for UserCommand {
                 new_password.to_owned(),
                 groups.to_owned(),
                 no_groups.to_owned(),
+                location.to_owned(),
+                job_title.to_owned(),
+                timezone.to_owned(),
+                date_format.to_owned(),
+                appearance.to_owned(),
+            ),
+            UserCommand::ProfileUpdate {
+                name,
+                location,
+                job_title,
+                timezone,
+                date_format,
+                appearance,
+            } => user_profile_update(
+                api,
+                name.to_owned(),
                 location.to_owned(),
                 job_title.to_owned(),
                 timezone.to_owned(),
@@ -464,5 +501,27 @@ fn user_update(
         appearance,
     )?;
     println!("{}: User updated", "success".bold().green());
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn user_profile_update(
+    api: wikijs::Api,
+    name: String,
+    location: String,
+    job_title: String,
+    timezone: String,
+    date_format: String,
+    appearance: String,
+) -> Result<(), Box<dyn Error>> {
+    api.user_profile_update(
+        name,
+        location,
+        job_title,
+        timezone,
+        date_format,
+        appearance,
+    )?;
+    println!("{}: User profile updated", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -60,6 +60,12 @@ pub(crate) enum UserCommand {
         #[clap(help = "User ID")]
         id: i64,
     },
+
+    #[clap(about = "Deactivate a user")]
+    Deactivate {
+        #[clap(help = "User ID")]
+        id: i64,
+    },
 }
 
 impl Execute for UserCommand {
@@ -88,6 +94,7 @@ impl Execute for UserCommand {
                 *send_welcome_email,
             ),
             UserCommand::Activate { id } => user_activate(api, *id),
+            UserCommand::Deactivate { id } => user_deactivate(api, *id),
         }
     }
 }
@@ -189,5 +196,11 @@ fn user_create(
 fn user_activate(api: wikijs::Api, id: i64) -> Result<(), Box<dyn Error>> {
     api.user_activate(id)?;
     println!("{}: User activated", "success".bold().green());
+    Ok(())
+}
+
+fn user_deactivate(api: wikijs::Api, id: i64) -> Result<(), Box<dyn Error>> {
+    api.user_deactivate(id)?;
+    println!("{}: User deactivated", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -96,6 +96,9 @@ pub(crate) enum UserCommand {
         #[clap(help = "The query to search for")]
         query: String,
     },
+
+    #[clap(about = "Get your own user profile")]
+    Profile {},
 }
 
 impl Execute for UserCommand {
@@ -131,6 +134,7 @@ impl Execute for UserCommand {
             UserCommand::Tfa { id, enabled } => user_tfa(api, *id, *enabled),
             UserCommand::Verify { id } => user_verify(api, *id),
             UserCommand::Search { query } => user_search(api, query.to_owned()),
+            UserCommand::Profile {} => user_profile(api),
         }
     }
 }
@@ -296,6 +300,40 @@ fn user_search(api: wikijs::Api, query: String) -> Result<(), Box<dyn Error>> {
             user.last_login_at.unwrap_or("".to_string()).as_str(),
         ]);
     }
+    println!("{}", builder.build().with(Style::rounded()));
+    Ok(())
+}
+
+fn user_profile(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+    let user = api.user_profile_get()?;
+    let mut builder = Builder::new();
+    builder.push_record(["key", "value"]);
+    builder.push_record(["id", user.id.to_string().as_str()]);
+    builder.push_record(["name", user.name.as_str()]);
+    builder.push_record(["email", user.email.as_str()]);
+    builder.push_record([
+        "provider_key",
+        user.provider_key.unwrap_or("".to_string()).as_str(),
+    ]);
+    builder.push_record([
+        "provider_name",
+        user.provider_name.unwrap_or("".to_string()).as_str(),
+    ]);
+    builder.push_record(["is_system", user.is_system.to_string().as_str()]);
+    builder.push_record(["is_verified", user.is_verified.to_string().as_str()]);
+    builder.push_record(["location", user.location.as_str()]);
+    builder.push_record(["job_title", user.job_title.as_str()]);
+    builder.push_record(["timezone", user.timezone.as_str()]);
+    builder.push_record(["date_format", user.date_format.as_str()]);
+    builder.push_record(["appearance", user.appearance.as_str()]);
+    builder.push_record(["created_at", user.created_at.to_string().as_str()]);
+    builder.push_record(["updated_at", user.updated_at.to_string().as_str()]);
+    builder.push_record([
+        "last_login_at",
+        user.last_login_at.unwrap_or("".to_string()).as_str(),
+    ]);
+    // groups
+    builder.push_record(["pages_total", user.pages_total.to_string().as_str()]);
     println!("{}", builder.build().with(Style::rounded()));
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -66,6 +66,15 @@ pub(crate) enum UserCommand {
         #[clap(help = "User ID")]
         id: i64,
     },
+
+    #[clap(about = "Delete a user")]
+    Delete {
+        #[clap(help = "User ID")]
+        id: i64,
+
+        #[clap(help = "Replace user ID")]
+        replace_id: i64,
+    },
 }
 
 impl Execute for UserCommand {
@@ -95,6 +104,9 @@ impl Execute for UserCommand {
             ),
             UserCommand::Activate { id } => user_activate(api, *id),
             UserCommand::Deactivate { id } => user_deactivate(api, *id),
+            UserCommand::Delete { id, replace_id } => {
+                user_delete(api, *id, *replace_id)
+            }
         }
     }
 }
@@ -202,5 +214,15 @@ fn user_activate(api: wikijs::Api, id: i64) -> Result<(), Box<dyn Error>> {
 fn user_deactivate(api: wikijs::Api, id: i64) -> Result<(), Box<dyn Error>> {
     api.user_deactivate(id)?;
     println!("{}: User deactivated", "success".bold().green());
+    Ok(())
+}
+
+fn user_delete(
+    api: wikijs::Api,
+    id: i64,
+    replace_id: i64,
+) -> Result<(), Box<dyn Error>> {
+    api.user_delete(id, replace_id)?;
+    println!("{}: User deleted", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -185,6 +185,12 @@ pub(crate) enum PasswordCommand {
         #[clap(help = "New password")]
         new: String,
     },
+
+    #[clap(about = "Reset a user's password")]
+    Reset {
+        #[clap(help = "User ID")]
+        id: i64,
+    },
 }
 
 impl Execute for UserCommand {
@@ -281,6 +287,7 @@ impl Execute for PasswordCommand {
             PasswordCommand::Change { current, new } => {
                 user_password_change(api, current.to_owned(), new.to_owned())
             }
+            PasswordCommand::Reset { id } => user_password_reset(api, *id),
         }
     }
 }
@@ -565,5 +572,14 @@ fn user_password_change(
 ) -> Result<(), Box<dyn Error>> {
     api.user_password_change(current, new)?;
     println!("{}: User password changed", "success".bold().green());
+    Ok(())
+}
+
+fn user_password_reset(
+    api: wikijs::Api,
+    id: i64,
+) -> Result<(), Box<dyn Error>> {
+    api.user_password_reset(id)?;
+    println!("{}: User password reset", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -418,11 +418,7 @@ fn user_profile(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
 fn user_last_logins(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
     let logins = api.user_last_login_list()?;
     let mut builder = Builder::new();
-    builder.push_record([
-        "id",
-        "name",
-        "last_login_at",
-    ]);
+    builder.push_record(["id", "name", "last_login_at"]);
     for login in logins {
         builder.push_record([
             login.id.to_string().as_str(),

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -99,6 +99,9 @@ pub(crate) enum UserCommand {
 
     #[clap(about = "Get your own user profile")]
     Profile {},
+
+    #[clap(about = "List the last logins")]
+    LastLogins {},
 }
 
 impl Execute for UserCommand {
@@ -135,6 +138,7 @@ impl Execute for UserCommand {
             UserCommand::Verify { id } => user_verify(api, *id),
             UserCommand::Search { query } => user_search(api, query.to_owned()),
             UserCommand::Profile {} => user_profile(api),
+            UserCommand::LastLogins {} => user_last_logins(api),
         }
     }
 }
@@ -334,6 +338,21 @@ fn user_profile(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
     ]);
     // groups
     builder.push_record(["pages_total", user.pages_total.to_string().as_str()]);
+    println!("{}", builder.build().with(Style::rounded()));
+    Ok(())
+}
+
+fn user_last_logins(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+    let logins = api.user_last_login_list()?;
+    let mut builder = Builder::new();
+    builder.push_record(["key", "value"]);
+    for login in logins {
+        builder.push_record([
+            login.id.to_string().as_str(),
+            login.name.to_string().as_str(),
+            login.last_login_at.to_string().as_str(),
+        ]);
+    }
     println!("{}", builder.build().with(Style::rounded()));
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -84,6 +84,12 @@ pub(crate) enum UserCommand {
         #[clap(help = "TFA enabled or not", action = ArgAction::Set)]
         enabled: bool,
     },
+
+    #[clap(about = "Verify a user")]
+    Verify {
+        #[clap(help = "User ID")]
+        id: i64,
+    },
 }
 
 impl Execute for UserCommand {
@@ -117,6 +123,7 @@ impl Execute for UserCommand {
                 user_delete(api, *id, *replace_id)
             }
             UserCommand::Tfa { id, enabled } => user_tfa(api, *id, *enabled),
+            UserCommand::Verify { id } => user_verify(api, *id),
         }
     }
 }
@@ -248,5 +255,11 @@ fn user_tfa(
         api.user_tfa_disable(id)?;
     }
     println!("{}: User TFA updated", "success".bold().green());
+    Ok(())
+}
+
+fn user_verify(api: wikijs::Api, id: i64) -> Result<(), Box<dyn Error>> {
+    api.user_verify(id)?;
+    println!("{}: User verified", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -175,6 +175,18 @@ pub(crate) enum ProfileCommand {
     },
 }
 
+#[derive(Subcommand)]
+pub(crate) enum PasswordCommand {
+    #[clap(about = "Change your password")]
+    Change {
+        #[clap(help = "Current password")]
+        current: String,
+
+        #[clap(help = "New password")]
+        new: String,
+    },
+}
+
 impl Execute for UserCommand {
     fn execute(&self, api: wikijs::Api) -> Result<(), Box<dyn Error>> {
         match self {
@@ -259,6 +271,16 @@ impl Execute for ProfileCommand {
                 date_format.to_owned(),
                 appearance.to_owned(),
             ),
+        }
+    }
+}
+
+impl Execute for PasswordCommand {
+    fn execute(&self, api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+        match self {
+            PasswordCommand::Change { current, new } => {
+                user_password_change(api, current.to_owned(), new.to_owned())
+            }
         }
     }
 }
@@ -533,5 +555,15 @@ fn user_profile_update(
         appearance,
     )?;
     println!("{}: User profile updated", "success".bold().green());
+    Ok(())
+}
+
+fn user_password_change(
+    api: wikijs::Api,
+    current: String,
+    new: String,
+) -> Result<(), Box<dyn Error>> {
+    api.user_password_change(current, new)?;
+    println!("{}: User password changed", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -1,5 +1,5 @@
 use crate::common::Execute;
-use clap::Subcommand;
+use clap::{ArgAction, Subcommand};
 use colored::Colorize;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
@@ -75,6 +75,15 @@ pub(crate) enum UserCommand {
         #[clap(help = "Replace user ID")]
         replace_id: i64,
     },
+
+    #[clap(about = "Turn on/off TFA for a user")]
+    Tfa {
+        #[clap(help = "User ID")]
+        id: i64,
+
+        #[clap(help = "TFA enabled or not", action = ArgAction::Set)]
+        enabled: bool,
+    },
 }
 
 impl Execute for UserCommand {
@@ -107,6 +116,7 @@ impl Execute for UserCommand {
             UserCommand::Delete { id, replace_id } => {
                 user_delete(api, *id, *replace_id)
             }
+            UserCommand::Tfa { id, enabled } => user_tfa(api, *id, *enabled),
         }
     }
 }
@@ -224,5 +234,19 @@ fn user_delete(
 ) -> Result<(), Box<dyn Error>> {
     api.user_delete(id, replace_id)?;
     println!("{}: User deleted", "success".bold().green());
+    Ok(())
+}
+
+fn user_tfa(
+    api: wikijs::Api,
+    id: i64,
+    enabled: bool,
+) -> Result<(), Box<dyn Error>> {
+    if enabled {
+        api.user_tfa_enable(id)?;
+    } else {
+        api.user_tfa_disable(id)?;
+    }
+    println!("{}: User TFA updated", "success".bold().green());
     Ok(())
 }

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -97,9 +97,6 @@ pub(crate) enum UserCommand {
         query: String,
     },
 
-    #[clap(about = "Get your own user profile")]
-    Profile {},
-
     #[clap(about = "List the last logins")]
     LastLogins {},
 
@@ -149,9 +146,15 @@ pub(crate) enum UserCommand {
         #[clap(short, long, help = "Appearance")]
         appearance: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum ProfileCommand {
+    #[clap(about = "Get your own user profile")]
+    Get {},
 
     #[clap(about = "Update your user profile")]
-    ProfileUpdate {
+    Update {
         #[clap(help = "Name")]
         name: String,
 
@@ -205,7 +208,6 @@ impl Execute for UserCommand {
             UserCommand::Tfa { id, enabled } => user_tfa(api, *id, *enabled),
             UserCommand::Verify { id } => user_verify(api, *id),
             UserCommand::Search { query } => user_search(api, query.to_owned()),
-            UserCommand::Profile {} => user_profile(api),
             UserCommand::LastLogins {} => user_last_logins(api),
             UserCommand::Update {
                 id,
@@ -233,7 +235,15 @@ impl Execute for UserCommand {
                 date_format.to_owned(),
                 appearance.to_owned(),
             ),
-            UserCommand::ProfileUpdate {
+        }
+    }
+}
+
+impl Execute for ProfileCommand {
+    fn execute(&self, api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+        match self {
+            ProfileCommand::Get {} => user_profile(api),
+            ProfileCommand::Update {
                 name,
                 location,
                 job_title,


### PR DESCRIPTION
This adds the following user commands:
- `user create`
- `user activate`
- `user deactivate`
- `user delete`
- `user tfa`
- `user verify`
- `user search`
- `user last-logins`
- `user update`
- `profile get`
- `profile update`
- `password change`
- `password reset`