### PR TITLE
Add Page Cache

### DIFF
--- a/gql/query/page/page_get_minimal.graphql
+++ b/gql/query/page/page_get_minimal.graphql
@@ -1,0 +1,13 @@
+query PageGetMinimal($id: Int!) {
+  pages {
+    single (id: $id) {
+      id
+      path
+      content
+      createdAt
+      updatedAt
+      editor
+      locale
+    }
+  }
+}

--- a/gql/query/page/page_get_updated_at.graphql
+++ b/gql/query/page/page_get_updated_at.graphql
@@ -1,0 +1,7 @@
+query PageGetUpdatedAt($id: Int!) {
+  pages {
+    single (id: $id) {
+      updatedAt
+    }
+  }
+}

--- a/src/fuse/main.rs
+++ b/src/fuse/main.rs
@@ -112,11 +112,12 @@ impl From<u64> for InodeType {
 struct Fs {
     api: Api,
     locale: String,
+    page_cache: page::PageCache,
 }
 
 impl Fs {
     pub fn new(api: Api, locale: String) -> Self {
-        Self { api, locale }
+        Self { api, locale, page_cache: page::PageCache::new() }
     }
 
     fn get_inode(&self, ino: u64) -> Option<Inode> {

--- a/src/fuse/main.rs
+++ b/src/fuse/main.rs
@@ -19,6 +19,8 @@ use colored::Colorize;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
 
+mod page;
+
 #[allow(clippy::large_enum_variant)]
 enum Inode {
     Page(Page),

--- a/src/fuse/main.rs
+++ b/src/fuse/main.rs
@@ -256,7 +256,11 @@ impl Filesystem for Fs {
             if size < content.len() as u64 {
                 content.truncate(std::cmp::max(size as usize, 1));
             }
-            match self.page_cache.update_content(&self.api, page.id as u64, content) {
+            match self.page_cache.update_content(
+                &self.api,
+                page.id as u64,
+                content,
+            ) {
                 Ok(_) => {
                     debug!("setattr: updated inode {}", ino);
                     let attr = match self.get_inode(ino) {
@@ -575,7 +579,10 @@ impl Filesystem for Fs {
         }
         debug!("write: inode {} from {} to {}", ino, offset, end);
 
-        match self.page_cache.update_content(&self.api, page.id as u64, content) {
+        match self
+            .page_cache
+            .update_content(&self.api, page.id as u64, content)
+        {
             Ok(_) => {
                 debug!("write: updated inode {}", ino);
                 reply.written(data.len() as u32);

--- a/src/fuse/main.rs
+++ b/src/fuse/main.rs
@@ -4,7 +4,7 @@ use fuser::{
     ReplyEntry, ReplyWrite, Request, TimeOrNow,
 };
 use libc::{EINVAL, EIO, EISDIR, ENOENT, O_TRUNC};
-use wikijs::page::{Page, PageTreeItem, PageTreeMode};
+use wikijs::page::{PageMinimal, PageTreeItem, PageTreeMode};
 use wikijs::{Api, Credentials};
 
 use chrono::DateTime;
@@ -23,7 +23,7 @@ mod page;
 
 #[allow(clippy::large_enum_variant)]
 enum Inode {
-    Page(Page),
+    Page(PageMinimal),
     Directory(Vec<PageTreeItem>),
 }
 
@@ -117,14 +117,18 @@ struct Fs {
 
 impl Fs {
     pub fn new(api: Api, locale: String) -> Self {
-        Self { api, locale, page_cache: page::PageCache::new() }
+        Self {
+            api,
+            locale,
+            page_cache: page::PageCache::new(),
+        }
     }
 
-    fn get_inode(&self, ino: u64) -> Option<Inode> {
+    fn get_inode(&mut self, ino: u64) -> Option<Inode> {
         match InodeType::from(ino) {
             InodeType::Page(id) => {
                 debug!("get_inode: page {}", id);
-                match self.api.page_get(id) {
+                match self.page_cache.get(&self.api, id as u64) {
                     Ok(page) => Some(Inode::Page(page)),
                     Err(_) => None,
                 }
@@ -252,7 +256,7 @@ impl Filesystem for Fs {
             if size < content.len() as u64 {
                 content.truncate(std::cmp::max(size as usize, 1));
             }
-            match self.api.page_update_content(page.id, content) {
+            match self.page_cache.update_content(&self.api, page.id as u64, content) {
                 Ok(_) => {
                     debug!("setattr: updated inode {}", ino);
                     let attr = match self.get_inode(ino) {
@@ -571,7 +575,7 @@ impl Filesystem for Fs {
         }
         debug!("write: inode {} from {} to {}", ino, offset, end);
 
-        match self.api.page_update_content(page.id, content) {
+        match self.page_cache.update_content(&self.api, page.id as u64, content) {
             Ok(_) => {
                 debug!("write: updated inode {}", ino);
                 reply.written(data.len() as u32);

--- a/src/fuse/page.rs
+++ b/src/fuse/page.rs
@@ -34,7 +34,7 @@ impl PageCache {
         self.pages.remove(&id);
     }
 
-    fn update(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
+    fn refetch(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
         self.pages.remove(&id);
         let page = api.page_get_minimal(id as i64)?;
         self.pages.insert(id, page.clone());

--- a/src/fuse/page.rs
+++ b/src/fuse/page.rs
@@ -7,6 +7,12 @@ pub(crate) struct PageCache {
 
 #[allow(dead_code)]
 impl PageCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            pages: HashMap::new(),
+        }
+    }
+
     fn get(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
         if let Some(page) = self.pages.get(&id) {
             let updated_at = api.page_get_updated_at(id as i64)?;

--- a/src/fuse/page.rs
+++ b/src/fuse/page.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use wikijs::{page::PageError, page::PageMinimal, Api};
+
+pub(crate) struct PageCache {
+    pages: HashMap<u64, PageMinimal>,
+}
+
+#[allow(dead_code)]
+impl PageCache {
+    fn get(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
+        if let Some(page) = self.pages.get(&id) {
+            let updated_at = api.page_get_updated_at(id as i64)?;
+            if updated_at != page.updated_at {
+                let page = api.page_get_minimal(id as i64)?;
+                self.pages.insert(id, page.clone());
+                Ok(page)
+            } else {
+                Ok(page.clone())
+            }
+        } else {
+            let page = api.page_get_minimal(id as i64)?;
+            self.pages.insert(id, page.clone());
+            Ok(page)
+        }
+    }
+
+    fn evict(&mut self, id: u64) {
+        self.pages.remove(&id);
+    }
+
+    fn update(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
+        self.pages.remove(&id);
+        let page = api.page_get_minimal(id as i64)?;
+        self.pages.insert(id, page.clone());
+        Ok(page)
+    }
+}

--- a/src/fuse/page.rs
+++ b/src/fuse/page.rs
@@ -13,7 +13,11 @@ impl PageCache {
         }
     }
 
-    pub(crate) fn get(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
+    pub(crate) fn get(
+        &mut self,
+        api: &Api,
+        id: u64,
+    ) -> Result<PageMinimal, PageError> {
         if let Some(page) = self.pages.get(&id) {
             let updated_at = api.page_get_updated_at(id as i64)?;
             if updated_at != page.updated_at {

--- a/src/fuse/page.rs
+++ b/src/fuse/page.rs
@@ -13,7 +13,7 @@ impl PageCache {
         }
     }
 
-    fn get(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
+    pub(crate) fn get(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
         if let Some(page) = self.pages.get(&id) {
             let updated_at = api.page_get_updated_at(id as i64)?;
             if updated_at != page.updated_at {
@@ -30,14 +30,29 @@ impl PageCache {
         }
     }
 
-    fn evict(&mut self, id: u64) {
+    pub(crate) fn evict(&mut self, id: u64) {
         self.pages.remove(&id);
     }
 
-    fn refetch(&mut self, api: &Api, id: u64) -> Result<PageMinimal, PageError> {
+    pub(crate) fn refetch(
+        &mut self,
+        api: &Api,
+        id: u64,
+    ) -> Result<PageMinimal, PageError> {
         self.pages.remove(&id);
         let page = api.page_get_minimal(id as i64)?;
         self.pages.insert(id, page.clone());
         Ok(page)
+    }
+
+    pub(crate) fn update_content(
+        &mut self,
+        api: &Api,
+        id: u64,
+        content: String,
+    ) -> Result<(), PageError> {
+        api.page_update_content(id as i64, content)?;
+        self.refetch(api, id)?;
+        Ok(())
     }
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -322,6 +322,20 @@ impl Api {
         )
     }
 
+    /// Get a page's minimal information. This function is crate internal for
+    /// now.
+    #[allow(dead_code)]
+    pub(crate) fn page_get_minimal(
+        &self,
+        id: i64,
+    ) -> Result<page::PageMinimal, page::PageError> {
+        page::page_get_minimal(
+            &self.client,
+            &format!("{}/graphql", self.url),
+            id,
+        )
+    }
+
     /// Get a page by its path.
     ///
     /// # Arguments

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -309,6 +309,19 @@ impl Api {
         page::page_get(&self.client, &format!("{}/graphql", self.url), id)
     }
 
+    /// Get a page's updated at date. This function is crate internal for now.
+    #[allow(dead_code)]
+    pub(crate) fn page_get_updated_at(
+        &self,
+        id: i64,
+    ) -> Result<String, page::PageError> {
+        page::page_get_updated_at(
+            &self.client,
+            &format!("{}/graphql", self.url),
+            id,
+        )
+    }
+
     /// Get a page by its path.
     ///
     /// # Arguments

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -309,9 +309,9 @@ impl Api {
         page::page_get(&self.client, &format!("{}/graphql", self.url), id)
     }
 
-    /// Get a page's updated at date. This function is crate internal for now.
+    /// Get a page's updated at date.
     #[allow(dead_code)]
-    pub(crate) fn page_get_updated_at(
+    pub fn page_get_updated_at(
         &self,
         id: i64,
     ) -> Result<String, page::PageError> {
@@ -322,10 +322,9 @@ impl Api {
         )
     }
 
-    /// Get a page's minimal information. This function is crate internal for
-    /// now.
+    /// Get a page's minimal information.
     #[allow(dead_code)]
-    pub(crate) fn page_get_minimal(
+    pub fn page_get_minimal(
         &self,
         id: i64,
     ) -> Result<page::PageMinimal, page::PageError> {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -309,7 +309,13 @@ impl Api {
         page::page_get(&self.client, &format!("{}/graphql", self.url), id)
     }
 
-    /// Get a page's updated at date.
+    /// Get datetime of last update of a page.
+    ///
+    /// # Arguments
+    /// * `id` - The id of the page to get the last update datetime of.
+    ///
+    /// # Returns
+    /// A Result containing either the datetime string or a page error.
     #[allow(dead_code)]
     pub fn page_get_updated_at(
         &self,
@@ -323,6 +329,12 @@ impl Api {
     }
 
     /// Get a page's minimal information.
+    ///
+    /// # Arguments
+    /// * `id` - The id of the page to get the minimal information of.
+    ///
+    /// # Returns
+    /// A Result containing either the minimal page information or a page error.
     #[allow(dead_code)]
     pub fn page_get_minimal(
         &self,

--- a/src/lib/page.rs
+++ b/src/lib/page.rs
@@ -2310,3 +2310,76 @@ pub fn page_history_purge(
     }
     Err(classify_response_error(response_body.errors))
 }
+
+pub(crate) mod page_get_updated_at {
+    use super::*;
+
+    pub struct PageGetUpdatedAt;
+
+    pub const OPERATION_NAME: &str = "PageGetUpdatedAt";
+    pub const QUERY : & str = "query PageGetUpdatedAt($id: Int!) {\n  pages {\n    single (id: $id) {\n      updatedAt\n    }\n  }\n}\n" ;
+
+    #[derive(Serialize)]
+    pub struct Variables {
+        pub id: Int,
+    }
+
+    impl Variables {}
+
+    #[derive(Deserialize)]
+    pub struct ResponseData {
+        pub pages: Option<Pages>,
+    }
+
+    #[derive(Deserialize)]
+    pub struct Pages {
+        pub single: Option<Single>,
+    }
+
+    #[derive(Deserialize)]
+    pub struct Single {
+        #[serde(rename = "updatedAt")]
+        pub updated_at: Date,
+    }
+
+    impl graphql_client::GraphQLQuery for PageGetUpdatedAt {
+        type Variables = Variables;
+        type ResponseData = ResponseData;
+        fn build_query(
+            variables: Self::Variables,
+        ) -> ::graphql_client::QueryBody<Self::Variables> {
+            ::graphql_client::QueryBody {
+                variables,
+                query: QUERY,
+                operation_name: OPERATION_NAME,
+            }
+        }
+    }
+}
+
+pub(crate) fn page_get_updated_at(
+    client: &Client,
+    url: &str,
+    id: i64,
+) -> Result<Date, PageError> {
+    let variables = page_get_updated_at::Variables { id };
+    let response = post_graphql::<page_get_updated_at::PageGetUpdatedAt, _>(
+        client, url, variables,
+    );
+    if response.is_err() {
+        return Err(PageError::UnknownErrorMessage {
+            message: response.err().unwrap().to_string(),
+        });
+    }
+
+    let response_body = response.unwrap();
+
+    if let Some(data) = response_body.data {
+        if let Some(pages) = data.pages {
+            if let Some(single) = pages.single {
+                return Ok(single.updated_at);
+            }
+        }
+    }
+    Err(classify_response_error(response_body.errors))
+}

--- a/src/lib/page.rs
+++ b/src/lib/page.rs
@@ -140,18 +140,18 @@ pub struct Page {
     pub creator_email: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 #[allow(dead_code)]
-pub(crate) struct PageMinimal {
-    pub(crate) id: Int,
-    pub(crate) path: String,
-    pub(crate) content: String,
+pub struct PageMinimal {
+    pub id: Int,
+    pub path: String,
+    pub content: String,
     #[serde(rename = "createdAt")]
-    pub(crate) created_at: Date,
+    pub created_at: Date,
     #[serde(rename = "updatedAt")]
-    pub(crate) updated_at: Date,
-    pub(crate) editor: String,
-    pub(crate) locale: String,
+    pub updated_at: Date,
+    pub editor: String,
+    pub locale: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -2371,7 +2371,7 @@ pub(crate) mod page_get_updated_at {
     }
 }
 
-pub(crate) fn page_get_updated_at(
+pub fn page_get_updated_at(
     client: &Client,
     url: &str,
     id: i64,
@@ -2438,7 +2438,7 @@ pub(crate) mod page_get_minimal {
     }
 }
 
-pub(crate) fn page_get_minimal(
+pub fn page_get_minimal(
     client: &Client,
     url: &str,
     id: i64,


### PR DESCRIPTION
This adds library functions `page_get_minimal` and `page_get_updated_at` and the `page.PageCache` to the FUSE code. `Fs` uses those to cache pages based on their `updated_at` field and only retrieve the actually needed data from the API.

Resolves #2 