### PR TITLE
Fix Login Panic and Add Clone Derives

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ use wikijs::{Api, Credentials};
 let api = Api::new(
     "http://localhost:3000".to_string(),
     Credentials::Key("my-api-key".to_string()),
-);
+).unwrap();
 println!("{:?}", api.page_get(1).unwrap());
 
 ```

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -123,7 +123,10 @@ enum Command {
 fn main() {
     let cli = Cli::parse();
     let credentials = Credentials::Key(cli.key.clone());
-    let api = Api::new(cli.url.clone(), credentials);
+    let api = Api::new(cli.url.clone(), credentials).unwrap_or_else(|e| {
+        eprintln!("{}: {}", "error".bold().red(), e);
+        std::process::exit(1);
+    });
 
     // TODO each command should be in its own module
     // TODO each subcommand should implement an Execute trait to call here

--- a/src/fuse/main.rs
+++ b/src/fuse/main.rs
@@ -699,7 +699,10 @@ fn main() {
     }
 
     let credentials = Credentials::Key(cli.key);
-    let api = Api::new(cli.url, credentials);
+    let api = Api::new(cli.url, credentials).unwrap_or_else(|error| {
+        error!("{}", error);
+        exit(1);
+    });
     let fs = Fs::new(api, cli.locale);
 
     mount2(fs, &cli.mountpoint, &[FSName("wikijs-fuse".to_string())])

--- a/src/lib/analytics.rs
+++ b/src/lib/analytics.rs
@@ -9,7 +9,7 @@ use crate::common::{
     UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum AnalyticsError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -50,7 +50,7 @@ impl KnownErrorCodes for AnalyticsError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AnalyticsProvider {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -65,7 +65,7 @@ pub struct AnalyticsProvider {
     pub config: Option<Vec<Option<KeyValuePair>>>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct AnalyticsProviderInput {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,

--- a/src/lib/asset.rs
+++ b/src/lib/asset.rs
@@ -8,7 +8,7 @@ use crate::common::{
     KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum AssetError {
     #[error("An unexpected error occurred during asset operation.")]
     AssetGenericError,
@@ -82,7 +82,7 @@ impl KnownErrorCodes for AssetError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AssetItem {
     pub id: Int,
     pub filename: String,
@@ -100,14 +100,14 @@ pub struct AssetItem {
     pub author: Option<Int>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AssetFolder {
     pub id: Int,
     pub slug: String,
     pub name: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum AssetKind {
     IMAGE,
     BINARY,

--- a/src/lib/authentication.rs
+++ b/src/lib/authentication.rs
@@ -174,7 +174,19 @@ pub fn login(
     if let Some(data) = response_body.data {
         if let Some(authentication) = data.authentication {
             if let Some(login) = authentication.login {
-                return Ok(login);
+                // TODO we need similar error handling
+                //      for other functions here, too
+                // TODO is this clone necessary?
+                let login_copy = login.clone();
+                if let Some(response_result) = login.response_result {
+                    if response_result.succeeded {
+                        return Ok(login_copy);
+                    } else {
+                        return Err(classify_response_status_error(
+                            response_result,
+                        ));
+                    }
+                }
             }
         }
     }

--- a/src/lib/authentication.rs
+++ b/src/lib/authentication.rs
@@ -8,7 +8,7 @@ use crate::common::{
 };
 use crate::user::UserError;
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AuthenticationLoginResponse {
     #[serde(rename = "responseResult")]
     pub response_result: Option<ResponseStatus>,
@@ -26,7 +26,7 @@ pub struct AuthenticationLoginResponse {
     pub tfa_qr_image: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct ApiKey {
     pub id: Int,
     pub name: String,
@@ -41,7 +41,7 @@ pub struct ApiKey {
     pub is_revoked: Boolean,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AuthenticationStrategy {
     pub key: String,
     pub props: Option<Vec<Option<KeyValuePair>>>,
@@ -59,7 +59,7 @@ pub struct AuthenticationStrategy {
     pub icon: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AuthenticationActiveStrategy {
     pub key: String,
     pub strategy: AuthenticationStrategy,
@@ -77,21 +77,21 @@ pub struct AuthenticationActiveStrategy {
     pub auto_enroll_groups: Vec<Option<Int>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AuthenticationCreateApiKeyResponse {
     #[serde(rename = "responseResult")]
     pub response_result: Option<ResponseStatus>,
     pub key: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct AuthenticationRegisterResponse {
     #[serde(rename = "responseResult")]
     pub response_result: Option<ResponseStatus>,
     pub jwt: Option<String>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct AuthenticationStrategyInput {
     pub key: String,
     #[serde(rename = "strategyKey")]

--- a/src/lib/comment.rs
+++ b/src/lib/comment.rs
@@ -9,7 +9,7 @@ use crate::common::{
     UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum CommentError {
     #[error("An unexpected error occurred.")]
     CommentGenericError,
@@ -70,7 +70,7 @@ impl KnownErrorCodes for CommentError {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct Comment {
     pub id: Int,
     pub content: String,
@@ -89,7 +89,7 @@ pub struct Comment {
     pub updated_at: Date,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct CommentProvider {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -103,7 +103,7 @@ pub struct CommentProvider {
     pub config: Option<Vec<Option<KeyValuePair>>>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct CommentProviderInput {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -111,14 +111,14 @@ pub struct CommentProviderInput {
     pub config: Option<Vec<Option<KeyValuePairInput>>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct CommentCreateResponse {
     #[serde(rename = "responseResult")]
     pub response_result: Option<ResponseStatus>,
     pub id: Option<Int>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct CommentUpdateResponse {
     #[serde(rename = "responseResult")]
     pub response_result: Option<ResponseStatus>,

--- a/src/lib/common.rs
+++ b/src/lib/common.rs
@@ -4,19 +4,19 @@ pub type Boolean = bool;
 pub type Int = i64;
 pub type Date = String;
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct KeyValuePair {
     pub key: String,
     pub value: String,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct KeyValuePairInput {
     pub key: String,
     pub value: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[allow(unused)]
 pub struct ResponseStatus {
     pub succeeded: Boolean,

--- a/src/lib/contribute.rs
+++ b/src/lib/contribute.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::common::{classify_response_error, Date, UnknownError};
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum ContributeError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -36,7 +36,7 @@ impl UnknownError for ContributeError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Contributor {
     pub id: String,
     pub source: String,

--- a/src/lib/group.rs
+++ b/src/lib/group.rs
@@ -9,7 +9,7 @@ use crate::common::{
 };
 use crate::user::UserMinimal;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum GroupError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -50,14 +50,14 @@ impl KnownErrorCodes for GroupError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct GroupResponse {
     #[serde(rename = "responseResult")]
     pub response_result: ResponseStatus,
     pub group: Option<Group>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct GroupMinimal {
     pub id: Int,
     pub name: String,
@@ -71,7 +71,7 @@ pub struct GroupMinimal {
     pub updated_at: Date,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Group {
     pub id: Int,
     pub name: String,
@@ -88,7 +88,7 @@ pub struct Group {
     pub updated_at: Date,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageRule {
     pub id: String,
     pub deny: Boolean,
@@ -98,7 +98,7 @@ pub struct PageRule {
     pub locales: Vec<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct PageRuleInput {
     pub id: String,
     pub deny: Boolean,
@@ -108,7 +108,7 @@ pub struct PageRuleInput {
     pub locales: Vec<String>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub enum PageRuleMatch {
     START,
     EXACT,

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -305,7 +305,7 @@ impl Api {
     /// let api = Api::new(
     ///     "http://localhost:3000".to_string(),
     ///     Credentials::Key("my-api-key".to_string()),
-    /// );
+    /// ).unwrap();
     /// println!("{:?}", api.page_get(1).unwrap());
     /// ```
     pub fn page_get(&self, id: i64) -> Result<page::Page, page::PageError> {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -130,7 +130,7 @@ impl Api {
     /// A new API struct.
     pub fn new(
         url: String,
-        credentials: Credentials
+        credentials: Credentials,
     ) -> Result<Self, user::UserError> {
         let key = match credentials {
             Credentials::Key(key) => key,

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -128,7 +128,10 @@ impl Api {
     ///
     /// # Returns
     /// A new API struct.
-    pub fn new(url: String, credentials: Credentials) -> Self {
+    pub fn new(
+        url: String,
+        credentials: Credentials
+    ) -> Result<Self, user::UserError> {
         let key = match credentials {
             Credentials::Key(key) => key,
             Credentials::UsernamePassword(username, password, strategy) => {
@@ -142,12 +145,12 @@ impl Api {
                     username,
                     password,
                     strategy,
-                )
-                .unwrap();
+                )?;
+                println!("{:?}", auth_response);
                 auth_response.jwt.unwrap()
             }
         };
-        Self {
+        Ok(Self {
             url,
             client: Client::builder()
                 .user_agent("wikijs-rs/0.1.0")
@@ -161,7 +164,7 @@ impl Api {
                 )
                 .build()
                 .unwrap(),
-        }
+        })
     }
 
     // asset functions

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -25,7 +25,7 @@
 //! let api = Api::new(
 //!     "http://localhost:3000".to_string(),
 //!     Credentials::Key("my-api-key".to_string()),
-//! );
+//! ).unwrap();
 //! // this returns a page::Page
 //! let page = api.page_get(1).unwrap();
 //! println!("{:?}", page);

--- a/src/lib/localization.rs
+++ b/src/lib/localization.rs
@@ -8,7 +8,7 @@ use crate::common::{
     Int, KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum LocaleError {
     #[error("An unexpected error occurred during locale operation.")]
     LocaleGenericError,
@@ -57,7 +57,7 @@ impl KnownErrorCodes for LocaleError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Locale {
     pub availability: Int,
     pub code: String,
@@ -76,7 +76,7 @@ pub struct Locale {
     pub updated_at: Date,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct LocaleConfig {
     pub locale: String,
     #[serde(rename = "autoUpdate")]
@@ -85,7 +85,7 @@ pub struct LocaleConfig {
     pub namespaces: Vec<Option<String>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Translation {
     pub key: String,
     pub value: String,

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -9,7 +9,7 @@ use crate::common::{
     UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum LoggingError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -50,7 +50,7 @@ impl KnownErrorCodes for LoggingError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Logger {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -63,7 +63,7 @@ pub struct Logger {
     pub config: Option<Vec<Option<KeyValuePair>>>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct LoggerInput {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,

--- a/src/lib/mail.rs
+++ b/src/lib/mail.rs
@@ -8,7 +8,7 @@ use crate::common::{
     KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum MailError {
     #[error("An unexpected error occurred during mail operation.")]
     MailGenericError,
@@ -63,7 +63,7 @@ impl KnownErrorCodes for MailError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct MailConfig {
     #[serde(rename = "senderName")]
     pub sender_name: Option<String>,

--- a/src/lib/navigation.rs
+++ b/src/lib/navigation.rs
@@ -8,7 +8,7 @@ use crate::common::{
     KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum NavigationError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -49,7 +49,7 @@ impl KnownErrorCodes for NavigationError {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub enum NavigationMode {
     NONE,
     TREE,
@@ -57,18 +57,18 @@ pub enum NavigationMode {
     STATIC,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct NavigationConfig {
     pub mode: NavigationMode,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct NavigationTree {
     pub locale: String,
     pub items: Vec<Option<NavigationTreeItem>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct NavigationTreeItem {
     pub id: String,
     pub kind: String,
@@ -83,13 +83,13 @@ pub struct NavigationTreeItem {
     pub visibility_groups: Option<Vec<Option<Int>>>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct NavigationTreeInput {
     pub locale: String,
     pub items: Vec<Option<NavigationItemInput>>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct NavigationItemInput {
     pub id: String,
     pub kind: String,

--- a/src/lib/page.rs
+++ b/src/lib/page.rs
@@ -140,7 +140,7 @@ pub struct Page {
     pub creator_email: String,
 }
 
-#[derive(Clone, Deserialize, Debug, Clone)]
+#[derive(Clone, Deserialize, Debug)]
 #[allow(dead_code)]
 pub struct PageMinimal {
     pub id: Int,

--- a/src/lib/page.rs
+++ b/src/lib/page.rs
@@ -8,7 +8,7 @@ use crate::common::{
     Int, KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum PageError {
     #[error("An unexpected error occurred during a page operation.")]
     PageGenericError,
@@ -93,7 +93,7 @@ impl KnownErrorCodes for PageError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Page {
     pub id: Int,
     pub path: String,
@@ -140,7 +140,7 @@ pub struct Page {
     pub creator_email: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Clone, Deserialize, Debug, Clone)]
 #[allow(dead_code)]
 pub struct PageMinimal {
     pub id: Int,
@@ -154,7 +154,7 @@ pub struct PageMinimal {
     pub locale: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageListItem {
     pub id: Int,
     pub path: String,
@@ -176,7 +176,7 @@ pub struct PageListItem {
     pub tags: Option<Vec<Option<String>>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageTreeItem {
     pub id: Int,
     pub path: String,
@@ -194,7 +194,7 @@ pub struct PageTreeItem {
     pub locale: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageTag {
     pub id: Int,
     pub tag: String,
@@ -205,14 +205,14 @@ pub struct PageTag {
     pub updated_at: Date,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub enum PageTreeMode {
     FOLDERS,
     PAGES,
     ALL,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub enum PageOrderBy {
     CREATED,
     ID,
@@ -221,19 +221,19 @@ pub enum PageOrderBy {
     UPDATED,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub enum PageOrderByDirection {
     ASC,
     DESC,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageHistoryResult {
     pub trail: Option<Vec<Option<PageHistory>>>,
     pub total: Int,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageHistory {
     #[serde(rename = "versionId")]
     pub version_id: Int,
@@ -251,7 +251,7 @@ pub struct PageHistory {
     pub value_after: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageVersion {
     pub action: String,
     #[serde(rename = "authorId")]
@@ -285,7 +285,7 @@ pub struct PageVersion {
     pub version_id: Int,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageSearchResponse {
     pub results: Vec<Option<PageSearchResult>>,
     pub suggestions: Vec<Option<String>>,
@@ -293,7 +293,7 @@ pub struct PageSearchResponse {
     pub total_hits: Int,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageSearchResult {
     pub id: String,
     pub title: String,
@@ -302,7 +302,7 @@ pub struct PageSearchResult {
     pub locale: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageLinkItem {
     pub id: Int,
     pub path: String,
@@ -310,7 +310,7 @@ pub struct PageLinkItem {
     pub links: Vec<Option<String>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct PageConflictLatest {
     pub id: Int,
     #[serde(rename = "authorId")]

--- a/src/lib/rendering.rs
+++ b/src/lib/rendering.rs
@@ -9,7 +9,7 @@ use crate::common::{
     UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum RenderingError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -50,7 +50,7 @@ impl KnownErrorCodes for RenderingError {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct Renderer {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -65,7 +65,7 @@ pub struct Renderer {
     pub config: Option<Vec<Option<KeyValuePair>>>,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct RendererInput {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,

--- a/src/lib/search.rs
+++ b/src/lib/search.rs
@@ -9,7 +9,7 @@ use crate::common::{
     UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum SearchError {
     #[error("An unexpected error occurred during search operation.")]
     SearchGenericError,
@@ -58,7 +58,7 @@ impl KnownErrorCodes for SearchError {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct SearchEngine {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -72,7 +72,7 @@ pub struct SearchEngine {
     pub config: Option<Vec<Option<KeyValuePair>>>,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct SearchEngineInput {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,

--- a/src/lib/site.rs
+++ b/src/lib/site.rs
@@ -8,7 +8,7 @@ use crate::common::{
     KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum SiteError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -49,7 +49,7 @@ impl KnownErrorCodes for SiteError {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct SiteConfig {
     pub host: Option<String>,
     pub title: Option<String>,

--- a/src/lib/storage.rs
+++ b/src/lib/storage.rs
@@ -9,7 +9,7 @@ use crate::common::{
     UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum StorageError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -50,7 +50,7 @@ impl KnownErrorCodes for StorageError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct StorageStatus {
     pub key: String,
     pub title: String,
@@ -60,7 +60,7 @@ pub struct StorageStatus {
     pub last_attempt: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct StorageTarget {
     #[serde(rename = "isAvailable")]
     pub is_available: Boolean,
@@ -84,7 +84,7 @@ pub struct StorageTarget {
     pub actions: Option<Vec<Option<StorageTargetAction>>>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct StorageTargetInput {
     #[serde(rename = "isEnabled")]
     pub is_enabled: Boolean,
@@ -95,7 +95,7 @@ pub struct StorageTargetInput {
     pub config: Option<Vec<Option<KeyValuePairInput>>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct StorageTargetAction {
     pub handler: String,
     pub label: String,

--- a/src/lib/system.rs
+++ b/src/lib/system.rs
@@ -8,7 +8,7 @@ use crate::common::{
     Int, KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum SystemError {
     #[error("An unexpected error occurred.")]
     SystemGenericError,
@@ -63,13 +63,13 @@ impl KnownErrorCodes for SystemError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct SystemFlag {
     pub key: String,
     pub value: Boolean,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct SystemInfo {
     #[serde(rename = "configFile")]
     pub config_file: Option<String>,
@@ -128,7 +128,7 @@ pub struct SystemInfo {
     pub working_directory: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct SystemExtension {
     pub key: String,
     pub title: String,
@@ -139,20 +139,20 @@ pub struct SystemExtension {
     pub is_compatible: Boolean,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub struct SystemFlagInput {
     pub key: String,
     pub value: Boolean,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Clone, Serialize, Debug)]
 pub enum SystemImportUsersGroupMode {
     MULTI,
     SINGLE,
     NONE,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct SystemExportStatus {
     pub status: Option<String>,
     pub progress: Option<Int>,

--- a/src/lib/theming.rs
+++ b/src/lib/theming.rs
@@ -8,7 +8,7 @@ use crate::common::{
     KnownErrorCodes, ResponseStatus, UnknownError,
 };
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum ThemeError {
     #[error("Unknown response error code: {code}: {message}")]
     UnknownErrorCode { code: i64, message: String },
@@ -49,14 +49,14 @@ impl KnownErrorCodes for ThemeError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct Theme {
     pub key: Option<String>,
     pub title: Option<String>,
     pub author: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct ThemingConfig {
     pub theme: String,
     pub iconset: String,

--- a/src/lib/user.rs
+++ b/src/lib/user.rs
@@ -9,7 +9,7 @@ use crate::common::{
 };
 use crate::group::Group;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum UserError {
     #[error("An unexpected error occurred during login.")]
     AuthGenericError,
@@ -117,14 +117,14 @@ impl KnownErrorCodes for UserError {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct UserResponse {
     #[serde(rename = "responseResult")]
     pub response_result: ResponseStatus,
     pub user: Option<User>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct UserLastLogin {
     pub id: Int,
     pub name: String,
@@ -132,7 +132,7 @@ pub struct UserLastLogin {
     pub last_login_at: Date,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct UserMinimal {
     pub id: Int,
     pub name: String,
@@ -149,7 +149,7 @@ pub struct UserMinimal {
     pub last_login_at: Option<Date>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct User {
     pub id: Int,
     pub name: String,
@@ -186,7 +186,7 @@ pub struct User {
     pub groups: Vec<Option<Group>>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct UserProfile {
     pub id: Int,
     pub name: String,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,5 +9,5 @@ lazy_static! {
             "password".to_string(),
             "local".to_string(),
         ),
-    );
+    ).unwrap_or_else(|e| panic!("Error creating API: {}", e));
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,5 +9,6 @@ lazy_static! {
             "password".to_string(),
             "local".to_string(),
         ),
-    ).unwrap_or_else(|e| panic!("Error creating API: {}", e));
+    )
+    .unwrap_or_else(|e| panic!("Error creating API: {}", e));
 }


### PR DESCRIPTION
This adds further error handling to `lib::authentication::login` and changes `lib::Api::new` to return `Result<Api, UserError>`.

This also adds derives of Clone to all public structs and enums.

Fixes #11