### PR TITLE
Add Password Authentication to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,17 @@ environment variables. For the latter option use something like this:
 export WIKI_JS_BASE_URL=https://wiki.mydomain.com
 export WIKI_JS_API_KEY=MY-SUPER-SECRET-API-KEY
 ```
-Then you can for example create a page named `test`, list pages and edit
-it with:
+or for password authentication use:
+```bash
+export WIKI_JS_USERNAME="USERNAME or EMAIL"
+export WIKI_JS_PASSWORD="PASSWORD"
+```
+Note, in case you're using something else then the default authentication
+provider like LDAP, you have to set the variable `WIKI_JS_AUTH_PROVIDER` to
+its UUID.
+
+Then you can for example create a page named `test`, list pages and edit it
+with:
 ```bash
 wikijs page create test
 wikijs page list

--- a/src/cli/analytics.rs
+++ b/src/cli/analytics.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum AnalyticsProviderCommand {
     #[clap(about = "List analytics providers")]
     List {},

--- a/src/cli/asset.rs
+++ b/src/cli/asset.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::Write;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum AssetCommand {
     #[clap(about = "List assets")]
     List {
@@ -36,7 +36,7 @@ pub(crate) enum AssetCommand {
     },
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum AssetFolderCommand {
     #[clap(about = "List asset folders")]
     List {

--- a/src/cli/authentication.rs
+++ b/src/cli/authentication.rs
@@ -1,0 +1,57 @@
+use crate::common::Execute;
+use clap::Subcommand;
+use std::error::Error;
+use tabled::{builder::Builder, settings::Style};
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum AuthenticationStrategyCommand {
+    #[clap(about = "List authentication strategies")]
+    List {},
+}
+
+impl Execute for AuthenticationStrategyCommand {
+    fn execute(&self, api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+        match self {
+            AuthenticationStrategyCommand::List {} => authentication_strategy_list(api),
+        }
+    }
+}
+
+fn authentication_strategy_list(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+    let providers = api.authentication_strategy_list()?;
+    let mut builder = Builder::new();
+    builder.push_record([
+        "key",
+        // "props",
+        "title",
+        // "description",
+        "is_available",
+        // "use_form",
+        // "username_type",
+        // "logo",
+        // "color",
+        // "website",
+        // "icon",
+    ]);
+    for provider in providers {
+        builder.push_record([
+            provider.key.as_str(),
+            // provider.props.as_str(),
+            provider.title.as_str(),
+            // provider.description.as_str(),
+            match provider.is_available {
+                Some(true) => "true",
+                Some(false) => "false",
+                None => "",
+            },
+            // provider.use_form.to_string().as_str(),
+            // provider.username_type.as_str(),
+            // provider.logo.as_str(),
+            // provider.color.as_str(),
+            // provider.website.as_str(),
+            // provider.icon.as_str(),
+        ]);
+    }
+    println!("{}", builder.build().with(Style::rounded()));
+    Ok(())
+}

--- a/src/cli/authentication.rs
+++ b/src/cli/authentication.rs
@@ -12,12 +12,16 @@ pub(crate) enum AuthenticationStrategyCommand {
 impl Execute for AuthenticationStrategyCommand {
     fn execute(&self, api: wikijs::Api) -> Result<(), Box<dyn Error>> {
         match self {
-            AuthenticationStrategyCommand::List {} => authentication_strategy_list(api),
+            AuthenticationStrategyCommand::List {} => {
+                authentication_strategy_list(api)
+            }
         }
     }
 }
 
-fn authentication_strategy_list(api: wikijs::Api) -> Result<(), Box<dyn Error>> {
+fn authentication_strategy_list(
+    api: wikijs::Api,
+) -> Result<(), Box<dyn Error>> {
     let providers = api.authentication_strategy_list()?;
     let mut builder = Builder::new();
     builder.push_record([

--- a/src/cli/comment.rs
+++ b/src/cli/comment.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum CommentCommand {
     #[clap(about = "List comments")]
     List {

--- a/src/cli/contribute.rs
+++ b/src/cli/contribute.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum ContributorCommand {
     #[clap(about = "List contributors")]
     List {},

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum GroupCommand {
     #[clap(about = "List groups")]
     List {

--- a/src/cli/localization.rs
+++ b/src/cli/localization.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum LocaleCommand {
     #[clap(about = "List locales")]
     List,

--- a/src/cli/logger.rs
+++ b/src/cli/logger.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum LoggerCommand {
     #[clap(about = "List loggers")]
     List {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2,9 +2,9 @@ use clap::{Args, Parser, Subcommand};
 use colored::Colorize;
 use wikijs::{Api, Credentials};
 
-mod authentication;
 mod analytics;
 mod asset;
+mod authentication;
 mod comment;
 mod common;
 mod contribute;
@@ -24,13 +24,33 @@ struct CredentialArgs {
     #[clap(short, long, help = "Wiki.js API key", env = "WIKI_JS_API_KEY")]
     key: Option<String>,
 
-    #[clap(short = 'U', long, help = "Wiki.js username", env = "WIKI_JS_USERNAME", requires = "password", conflicts_with = "key")]
+    #[clap(
+        short = 'U',
+        long,
+        help = "Wiki.js username",
+        env = "WIKI_JS_USERNAME",
+        requires = "password",
+        conflicts_with = "key"
+    )]
     username: Option<String>,
 
-    #[clap(short = 'P', long, help = "Wiki.js password", env = "WIKI_JS_PASSWORD", requires = "username", conflicts_with = "key")]
+    #[clap(
+        short = 'P',
+        long,
+        help = "Wiki.js password",
+        env = "WIKI_JS_PASSWORD",
+        requires = "username",
+        conflicts_with = "key"
+    )]
     password: Option<String>,
 
-    #[clap(short, long, help = "Wiki.js authentication provider ID", env = "WIKI_JS_AUTH_PROVIDER", default_value = "local")]
+    #[clap(
+        short,
+        long,
+        help = "Wiki.js authentication provider ID",
+        env = "WIKI_JS_AUTH_PROVIDER",
+        default_value = "local"
+    )]
     provider: Option<String>,
 }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use colored::Colorize;
 use wikijs::{Api, Credentials};
 
+mod authentication;
 mod analytics;
 mod asset;
 mod comment;
@@ -45,6 +46,12 @@ enum Command {
     AssetFolder {
         #[clap(subcommand)]
         command: asset::AssetFolderCommand,
+    },
+
+    #[clap(about = "Authentication strategy commands")]
+    AuthenticationStrategy {
+        #[clap(subcommand)]
+        command: authentication::AuthenticationStrategyCommand,
     },
 
     #[clap(about = "Page commands")]
@@ -134,6 +141,7 @@ fn main() {
     match match cli.command {
         Command::Asset { ref command } => command.execute(api),
         Command::AssetFolder { ref command } => command.execute(api),
+        Command::AuthenticationStrategy { ref command } => command.execute(api),
         Command::Page { ref command } => command.execute(api),
         Command::Contributor { ref command } => command.execute(api),
         Command::AnalyticsProvider { command } => command.execute(api),

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -17,7 +17,7 @@ mod user;
 
 use crate::common::Execute;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[command(name = "wikijs-cli")]
 #[command(author = "Sandro-Alessio Gierens <sandro@gierens.de>")]
 #[command(version = "0.1.1")]
@@ -33,7 +33,7 @@ struct Cli {
     command: Command,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 enum Command {
     #[clap(about = "Asset commands")]
     Asset {

--- a/src/cli/page.rs
+++ b/src/cli/page.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use tabled::{builder::Builder, settings::Style};
 use tempfile::Builder as TempFileBuilder;
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum PageCommand {
     #[clap(about = "Get a page")]
     Get {

--- a/src/cli/system.rs
+++ b/src/cli/system.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum SystemFlagCommand {
     #[clap(about = "List system flags")]
     List {},

--- a/src/cli/theming.rs
+++ b/src/cli/theming.rs
@@ -3,7 +3,7 @@ use clap::Subcommand;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum ThemeCommand {
     #[clap(about = "List themes")]
     List {},

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use std::error::Error;
 use tabled::{builder::Builder, settings::Style};
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum UserCommand {
     #[clap(about = "Get a user")]
     Get {
@@ -148,7 +148,7 @@ pub(crate) enum UserCommand {
     },
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum ProfileCommand {
     #[clap(about = "Get your own user profile")]
     Get {},
@@ -175,7 +175,7 @@ pub(crate) enum ProfileCommand {
     },
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 pub(crate) enum PasswordCommand {
     #[clap(about = "Change your password")]
     Change {


### PR DESCRIPTION
This adds password authentication to as alternative to API key authentication
to the CLI program. It also adds corresponding documentation in the README.

It furthermore adds Debug derivation on all parser and (sub)command structs
and enums, and the authentication-strategy list command.

Resolves #9