### PR TITLE
Add rustls-tls feature to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ vendored-tls = ["reqwest/native-tls-vendored"]
 # lib
 graphql_client = { version = "0.14", features = ["reqwest-blocking"] }
 serde = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "multipart"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "multipart", "rustls-tls"] }
 thiserror = "2.0"
 # cli and fuse
 clap = { version = "4.4", features = ["derive", "env"], optional = true }


### PR DESCRIPTION
Otherwise there is no HTTPS support, since we removed OpenSSL
by disabling reqwest's default-features.